### PR TITLE
feat: OAuth2 로그인 성공 핸들러, 토큰 발급 및 쿠키 저장 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     // Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
+    // OAuth2
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/ddobang/backend/domain/member/entity/Member.java
+++ b/src/main/java/com/ddobang/backend/domain/member/entity/Member.java
@@ -14,12 +14,17 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Member extends BaseTime {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,7 +37,7 @@ public class Member extends BaseTime {
 
 	private String introduction;
 
-	private Long kakaoId;
+	private String kakaoId;
 
 	private String profilePictureUrl;
 

--- a/src/main/java/com/ddobang/backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/ddobang/backend/domain/member/repository/MemberRepository.java
@@ -1,9 +1,13 @@
 package com.ddobang.backend.domain.member.repository;
 
-import com.ddobang.backend.domain.member.entity.Member;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.ddobang.backend.domain.member.entity.Member;
+
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
+	Optional<Member> findByOauthId(String kakaoId);
 }

--- a/src/main/java/com/ddobang/backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/ddobang/backend/domain/member/repository/MemberRepository.java
@@ -9,5 +9,5 @@ import com.ddobang.backend.domain.member.entity.Member;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
-	Optional<Member> findByOauthId(String kakaoId);
+	Optional<Member> findByKakaoId(String kakaoId);
 }

--- a/src/main/java/com/ddobang/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/ddobang/backend/domain/member/service/MemberService.java
@@ -1,11 +1,26 @@
 package com.ddobang.backend.domain.member.service;
 
-import com.ddobang.backend.domain.member.repository.MemberRepository;
-import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Service;
+
+import com.ddobang.backend.domain.member.entity.Member;
+import com.ddobang.backend.domain.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
-    private final MemberRepository memberRepository;
+	private final MemberRepository memberRepository;
+
+	// OAuth2User 정보로 회원 생성
+	public Member createMemberFromOAuth2(OidcUser oidcUser) {
+		String sub = oidcUser.getSubject();
+		String nickname = oidcUser.getAttribute("nickname");
+
+		return memberRepository.save(Member.builder()
+			.kakaoId(sub) // 카카오 ID
+			.nickname(nickname) // 닉네임
+			.build());
+	}
 }

--- a/src/main/java/com/ddobang/backend/global/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/ddobang/backend/global/security/oauth/OAuth2SuccessHandler.java
@@ -4,12 +4,13 @@ import java.io.IOException;
 import java.util.Optional;
 
 import org.springframework.security.core.Authentication;
-import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
 import com.ddobang.backend.domain.member.entity.Member;
 import com.ddobang.backend.domain.member.repository.MemberRepository;
+import com.ddobang.backend.domain.member.service.MemberService;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -22,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 	private final MemberRepository memberRepository;
+	private final MemberService memberService;
 
 	@Override
 	public void onAuthenticationSuccess(
@@ -31,20 +33,21 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 	) throws IOException, ServletException { // OAuth2 로그인 성공 시 처리될 내용
 		log.info("OAuth2 로그인 성공: {}", authentication.getName());
 
-		// 사용자 정보 추출 (카카오 ID 기준)
-		OAuth2User oAuth2User = (OAuth2User)authentication.getPrincipal();
-		String kakaoId = String.valueOf(oAuth2User.getAttribute("id")); // or "sub"
-
+		// 카카오 ID 추출
+		OidcUser oidcUser = (OidcUser)authentication.getPrincipal();
+		String kakaoId = oidcUser.getSubject(); //
 		log.info("카카오 ID: {}", kakaoId);
 
 		// 기존 회원 여부 확인
-		Optional<Member> existMember = memberRepository.findByOauthId(kakaoId);
+		Optional<Member> existMember = memberRepository.findByKakaoId(kakaoId);
 
+		// 기존 회원이면 로그인 처리
 		if (existMember.isPresent()) {
 			log.info("기존 회원: {}", kakaoId);
 		} else {
+			// 신규 회원이면 회원 생성
 			log.info("신규 회원입니다: {}", kakaoId);
-			// 신규회원 가입 처리 로직
+			memberService.createMemberFromOAuth2(oidcUser);
 		}
 	}
 }

--- a/src/main/java/com/ddobang/backend/global/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/ddobang/backend/global/security/oauth/OAuth2SuccessHandler.java
@@ -1,0 +1,27 @@
+package com.ddobang.backend.global.security.oauth;
+
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+	@Override
+	public void onAuthenticationSuccess(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		Authentication authentication
+	) throws IOException, ServletException { // OAuth2 로그인 성공 시 처리될 내용
+		log.info("OAuth2 로그인 성공: {}", authentication.getName());
+	}
+}

--- a/src/main/java/com/ddobang/backend/global/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/ddobang/backend/global/security/oauth/OAuth2SuccessHandler.java
@@ -1,10 +1,15 @@
 package com.ddobang.backend.global.security.oauth;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+
+import com.ddobang.backend.domain.member.entity.Member;
+import com.ddobang.backend.domain.member.repository.MemberRepository;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -16,6 +21,8 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+	private final MemberRepository memberRepository;
+
 	@Override
 	public void onAuthenticationSuccess(
 		HttpServletRequest request,
@@ -23,5 +30,21 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 		Authentication authentication
 	) throws IOException, ServletException { // OAuth2 로그인 성공 시 처리될 내용
 		log.info("OAuth2 로그인 성공: {}", authentication.getName());
+
+		// 사용자 정보 추출 (카카오 ID 기준)
+		OAuth2User oAuth2User = (OAuth2User)authentication.getPrincipal();
+		String kakaoId = String.valueOf(oAuth2User.getAttribute("id")); // or "sub"
+
+		log.info("카카오 ID: {}", kakaoId);
+
+		// 기존 회원 여부 확인
+		Optional<Member> existMember = memberRepository.findByOauthId(kakaoId);
+
+		if (existMember.isPresent()) {
+			log.info("기존 회원: {}", kakaoId);
+		} else {
+			log.info("신규 회원입니다: {}", kakaoId);
+			// 신규회원 가입 처리 로직
+		}
 	}
 }

--- a/src/main/java/com/ddobang/backend/global/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/ddobang/backend/global/security/oauth/OAuth2SuccessHandler.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Component;
 import com.ddobang.backend.domain.member.entity.Member;
 import com.ddobang.backend.domain.member.repository.MemberRepository;
 import com.ddobang.backend.domain.member.service.MemberService;
+import com.ddobang.backend.global.security.jwt.JwtTokenProvider;
+import com.ddobang.backend.global.util.CookieUtil;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -24,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 	private final MemberRepository memberRepository;
 	private final MemberService memberService;
+	private final JwtTokenProvider jwtTokenProvider;
 
 	@Override
 	public void onAuthenticationSuccess(
@@ -41,13 +44,26 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 		// 기존 회원 여부 확인
 		Optional<Member> existMember = memberRepository.findByKakaoId(kakaoId);
 
+		Member member;
+
 		// 기존 회원이면 로그인 처리
 		if (existMember.isPresent()) {
 			log.info("기존 회원: {}", kakaoId);
+			member = existMember.get(); // 회원 정보 가져오기
 		} else {
 			// 신규 회원이면 회원 생성
 			log.info("신규 회원입니다: {}", kakaoId);
-			memberService.createMemberFromOAuth2(oidcUser);
+			member = memberService.createMemberFromOAuth2(oidcUser); // 신규 회원 정보 가져오기
 		}
+
+		boolean isAdmin = member.getPassword() != null; // 비밀번호가 존재하면 관리자로 판단
+
+		String accessToken = jwtTokenProvider.generateAccessToken(member.getKakaoId(), isAdmin);
+		String refreshToken = jwtTokenProvider.generateRefreshToken(member.getKakaoId(), isAdmin);
+
+		response.addCookie(CookieUtil.createAccessTokenCookie(accessToken));
+		response.addCookie(CookieUtil.createRefreshTokenCookie(refreshToken));
+
+		log.info("JWT 토큰 생성 및 쿠키 전송 완료");
 	}
 }

--- a/src/main/java/com/ddobang/backend/global/util/CookieUtil.java
+++ b/src/main/java/com/ddobang/backend/global/util/CookieUtil.java
@@ -1,0 +1,40 @@
+package com.ddobang.backend.global.util;
+
+import jakarta.servlet.http.Cookie;
+
+public class CookieUtil {
+
+	private static final int ACCESS_TOKEN_EXPIRE_SEC = 60 * 30; // 30분
+	private static final int REFRESH_TOKEN_EXPIRE_SEC = 60 * 60 * 24; // 1일
+
+	private static final String ACCESS_TOKEN_KEY = "accessToken";
+	private static final String REFRESH_TOKEN_KEY = "refreshToken";
+
+	// Access Token 쿠키 생성
+	public static Cookie createAccessTokenCookie(String token) {
+		Cookie cookie = new Cookie(ACCESS_TOKEN_KEY, token);
+		cookie.setHttpOnly(true);
+		cookie.setSecure(false); // 배포 환경에서 true
+		cookie.setPath("/");
+		cookie.setMaxAge(ACCESS_TOKEN_EXPIRE_SEC);
+		return cookie;
+	}
+
+	// Refresh Token 쿠키 생성
+	public static Cookie createRefreshTokenCookie(String token) {
+		Cookie cookie = new Cookie(REFRESH_TOKEN_KEY, token);
+		cookie.setHttpOnly(true);
+		cookie.setSecure(false); // 배포 환경에서 true
+		cookie.setPath("/");
+		cookie.setMaxAge(REFRESH_TOKEN_EXPIRE_SEC);
+		return cookie;
+	}
+
+	// 쿠키 제거
+	public static Cookie deleteCookie(String name) {
+		Cookie cookie = new Cookie(name, null);
+		cookie.setMaxAge(0);
+		cookie.setPath("/");
+		return cookie;
+	}
+}

--- a/src/main/resources/application-secret.default.yml
+++ b/src/main/resources/application-secret.default.yml
@@ -2,3 +2,9 @@ jwt:
   secret: "PLEASE_CHANGE_ME" # JWT 암호화 키
   access-token-expiration: 3600000  # 1시간, 개발용
   refresh-token-expiration: 604800000  # 7일, 개발용
+
+oauth:
+  kakao:
+    client-id: "PLEASE_CHANGE_ME" # 카카오 REST API 키
+    client-secret: "PLEASE_CHANGE_ME" # 카카오 REST API 시크릿
+    redirect-uri: http://localhost:8080/login/oauth2/code/kakao # 카카오 로그인 후 리다이렉트 URI(개발용, 배포시 수정)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,6 +37,25 @@ spring:
         highlight_sql: true
         use_sql_comments: true
 
+  # Security
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${oauth.kakao.client-id}
+            client-secret: ${oauth.kakao.client-secret}
+            redirect-uri: ${oauth.kakao.redirect-uri}
+            authorization-grant-type: authorization_code
+            scope:
+              - openid
+              - profile_nickname
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            jwk-set-uri: https://kauth.kakao.com/.well-known/jwks.json
+
 # logging
 logging:
   level:

--- a/src/test/java/com/ddobang/backend/global/security/jwt/dto/TokenResponse.java
+++ b/src/test/java/com/ddobang/backend/global/security/jwt/dto/TokenResponse.java
@@ -1,0 +1,11 @@
+package com.ddobang.backend.global.security.jwt.dto;
+
+public record TokenResponse(
+	String token, // 토큰 값
+	TokenType tokenType, // 토큰 타입
+	long accessTokenExpiresIn // 엑세스 토큰 만료 시간
+) {
+	public static TokenResponse of(String token, TokenType tokenType, long expiresIn) {
+		return new TokenResponse(token, tokenType, expiresIn);
+	}
+}

--- a/src/test/java/com/ddobang/backend/global/security/jwt/dto/TokenType.java
+++ b/src/test/java/com/ddobang/backend/global/security/jwt/dto/TokenType.java
@@ -1,0 +1,6 @@
+package com.ddobang.backend.global.security.jwt.dto;
+
+public enum TokenType {
+	ACCESS,
+	REFRESH
+}


### PR DESCRIPTION
## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?
 - 인증로직 완성 후 단위/통합 테스트 구현
  <br/>

## 🔎 작업 내용
- 카카오 OAuth2 로그인 OAuth2SuccessHandler 구현
- 카카오ID로 회원 여부 조회 및 신규 회원 자동 등록
- JwtTokenProvider를 통해 Access Token / Refresh Token 발급
- 발급한 토큰을 HttpOnly 쿠키에 담아 응답에 포함
- 기존/신규 회원 여부 상관없이 공통 로직으로 토큰 생성 처리
- 유틸 CookieUtil을 사용하여 쿠키 생성

## 관련 이슈
Closes #36 
Closes #38 