### PR TITLE
fix: SecurityConfig에서 MVC 요청 충돌 이슈 해결 (#69)

### DIFF
--- a/src/main/java/com/ddobang/backend/global/security/SecurityConfig.java
+++ b/src/main/java/com/ddobang/backend/global/security/SecurityConfig.java
@@ -47,15 +47,15 @@ public class SecurityConfig {
 					.requestMatchers("/admin/**").hasRole("ADMIN")
 
 					// 닉네임 중복 체크
-					.requestMatchers("api/v1/members/check-nickname").permitAll()
+					.requestMatchers("/api/v1/members/check-nickname").permitAll()
 
 					// 공개 API
-					.requestMatchers("api/v1/regions").permitAll()
-					.requestMatchers("api/v1/themes").permitAll()
-					.requestMatchers("api/v1/themes/*").permitAll()
-					.requestMatchers("api/v1/parties").permitAll()
-					.requestMatchers("api/v1/parties/*").permitAll()
-					.requestMatchers("api/v1/stores/*").permitAll()
+					.requestMatchers("/api/v1/regions").permitAll()
+					.requestMatchers("/api/v1/themes").permitAll()
+					.requestMatchers("/api/v1/themes/*").permitAll()
+					.requestMatchers("/api/v1/parties").permitAll()
+					.requestMatchers("/api/v1/parties/*").permitAll()
+					.requestMatchers("/api/v1/stores/*").permitAll()
 
 					// 인증 필요 API
 					.anyRequest().hasAnyRole("MEMBER", "ADMIN");

--- a/src/main/java/com/ddobang/backend/global/security/SecurityConfig.java
+++ b/src/main/java/com/ddobang/backend/global/security/SecurityConfig.java
@@ -8,7 +8,6 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher;
 import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 
 import com.ddobang.backend.global.security.jwt.JwtAuthenticationFilter;
@@ -27,9 +26,6 @@ public class SecurityConfig {
 	@Bean
 	public SecurityFilterChain securityFilterChain(
 		HttpSecurity http, HandlerMappingIntrospector introspector) throws Exception {
-
-		// MvcRequestMatcher를 사용하여 URL 패턴 매칭
-		MvcRequestMatcher.Builder mvc = new MvcRequestMatcher.Builder(introspector).servletPath("/api/v1");
 
 		http
 			.cors(Customizer.withDefaults())
@@ -51,15 +47,15 @@ public class SecurityConfig {
 					.requestMatchers("/admin/**").hasRole("ADMIN")
 
 					// 닉네임 중복 체크
-					.requestMatchers(mvc.pattern("/members/check-nickname")).permitAll()
+					.requestMatchers("api/v1/members/check-nickname").permitAll()
 
 					// 공개 API
-					.requestMatchers(mvc.pattern("/regions")).permitAll()
-					.requestMatchers(mvc.pattern("/themes")).permitAll()
-					.requestMatchers(mvc.pattern("/themes/*")).permitAll()
-					.requestMatchers(mvc.pattern("/parties")).permitAll()
-					.requestMatchers(mvc.pattern("/parties/*")).permitAll()
-					.requestMatchers(mvc.pattern("/stores/*")).permitAll()
+					.requestMatchers("api/v1/regions").permitAll()
+					.requestMatchers("api/v1/themes").permitAll()
+					.requestMatchers("api/v1/themes/*").permitAll()
+					.requestMatchers("api/v1/parties").permitAll()
+					.requestMatchers("api/v1/parties/*").permitAll()
+					.requestMatchers("api/v1/stores/*").permitAll()
 
 					// 인증 필요 API
 					.anyRequest().hasAnyRole("MEMBER", "ADMIN");

--- a/src/test/java/com/ddobang/backend/global/security/TestSecurityConfig.java
+++ b/src/test/java/com/ddobang/backend/global/security/TestSecurityConfig.java
@@ -1,0 +1,28 @@
+package com.ddobang.backend.global.security;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@TestConfiguration
+@Profile("test")
+public class TestSecurityConfig {
+
+	// 테스트 환경에서는 JWT 인증을 사용하지 않음
+	@Bean
+	public SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+		http
+			.csrf(AbstractHttpConfigurer::disable)
+			.authorizeHttpRequests(auth -> auth
+				.anyRequest().permitAll() // 모든 요청 허용
+			)
+			.sessionManagement(AbstractHttpConfigurer::disable); // 세션도 꺼도 됨 (JWT 안 쓸 거니까)
+
+		return http.build();
+	}
+}


### PR DESCRIPTION
<!-- 제목 : [FEAT] 구현한 기능 -->
<!-- #[이슈 번호] -->

## ✔️PR Type
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 변경 내용
SecurityConfig 에서 mvcMatchers() 를 사용해 인증 제외 경로를 설정했지만, 일부 MVC 패턴 경로에서 인증이 여전히 요구되는 문제가 발생했습니다.  
이에 따라 해당 경로들을 requestMatchers()로 직접 명시하여 인증 없이 접근 가능하도록 수정했습니다.

Closed #69 