### PR TITLE
feat: CORS 설정 및 preflight 요청 대응 통합 테스트 추가

### DIFF
--- a/src/main/java/com/ddobang/backend/global/auth/controller/AuthController.java
+++ b/src/main/java/com/ddobang/backend/global/auth/controller/AuthController.java
@@ -1,0 +1,19 @@
+package com.ddobang.backend.global.auth.controller;
+
+import java.io.IOException;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+@Controller
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+	@GetMapping("/login")
+	public void kakaoLogin(HttpServletResponse response) throws IOException {
+		response.sendRedirect("/oauth2/authorization/kakao");
+	}
+}

--- a/src/main/java/com/ddobang/backend/global/security/SecurityConfig.java
+++ b/src/main/java/com/ddobang/backend/global/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -28,6 +29,9 @@ public class SecurityConfig {
 	private final JwtTokenProvider jwtTokenProvider;
 	private final OAuth2SuccessHandler oAuth2SuccessHandler;
 
+	/**
+	 * SecurityFilterChain 설정
+	 */
 	@Bean
 	public SecurityFilterChain securityFilterChain(
 		HttpSecurity http, HandlerMappingIntrospector introspector) throws Exception {
@@ -55,10 +59,12 @@ public class SecurityConfig {
 					.requestMatchers("/api/v1/members/check-nickname").permitAll()
 
 					// 공개 API
-					.requestMatchers("/api/v1/regions").permitAll()
+					.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll() // CORS preflight 요청 허용
+					.requestMatchers(HttpMethod.GET, "/api/v1/regions").permitAll()      // 지역 조회
 					.requestMatchers("/api/v1/themes").permitAll()
 					.requestMatchers("/api/v1/themes/*").permitAll()
 					.requestMatchers("/api/v1/parties").permitAll()
+					.requestMatchers(HttpMethod.POST, "/api/v1/auth/signup").permitAll() // 회원가입
 					.requestMatchers("/api/v1/parties/*").permitAll()
 					.requestMatchers("/api/v1/stores/*").permitAll()
 

--- a/src/main/java/com/ddobang/backend/global/security/SecurityConfig.java
+++ b/src/main/java/com/ddobang/backend/global/security/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.ddobang.backend.global.security;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -8,6 +10,9 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 
 import com.ddobang.backend.global.security.jwt.JwtAuthenticationFilter;
@@ -76,5 +81,26 @@ public class SecurityConfig {
 			);
 
 		return http.build();
+	}
+
+	/**
+	 * CORS 설정
+	 * @return CorsConfigurationSource
+	 */
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+		configuration.setAllowedOrigins(List.of(
+			"http://localhost:3000",                       // 로컬 개발용
+			"https://ddobang.site",                        // 배포 주소
+			"https://web-1-2-pitching-mate-fe.vercel.app"  // Vercel 배포 주소
+		));
+		configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+		configuration.setAllowedHeaders(List.of("*"));
+		configuration.setAllowCredentials(true); // 인증 정보 전송 허용
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
 	}
 }

--- a/src/test/java/com/ddobang/backend/global/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/ddobang/backend/global/auth/controller/AuthControllerTest.java
@@ -1,0 +1,30 @@
+package com.ddobang.backend.global.auth.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * 로그인 관련 API 테스트
+ * @author Jay Lim
+ */
+@WebMvcTest(AuthController.class)
+@DisplayName("AuthController 테스트")
+class AuthControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("t1 - 카카오 로그인 리다이렉트 확인")
+	void t1() throws Exception {
+		mockMvc.perform(get("/api/v1/auth/login"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrlPattern("**/oauth2/authorization/kakao"));
+	}
+}

--- a/src/test/java/com/ddobang/backend/global/config/CorsConfigIntegrationTest.java
+++ b/src/test/java/com/ddobang/backend/global/config/CorsConfigIntegrationTest.java
@@ -1,0 +1,41 @@
+package com.ddobang.backend.global.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * CORS 설정이 정상 동작하는지 확인하는 통합 테스트
+ * - 프론트엔드에서 보내는 OPTIONS 요청에 대해 허용 헤더가 포함되어 응답되는지 확인한다.
+ * @author Jay Lim
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class CorsConfigIntegrationTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("CORS - 프론트엔드에서 보내는 OPTIONS 요청에 대해 허용 헤더가 포함되어 응답된다")
+	void CORS01() throws Exception {
+		// given
+		String frontendOrigin = "https://web-1-2-pitching-mate-fe.vercel.app";
+
+		// when & then
+		mockMvc.perform(options("/api/v1/regions")
+				.header(HttpHeaders.ORIGIN, frontendOrigin)
+				.header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET"))
+			.andExpect(status().isOk())
+			.andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, frontendOrigin))
+			.andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, "GET,POST,PUT,DELETE,PATCH,OPTIONS"))
+			.andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true"));
+	}
+}


### PR DESCRIPTION
<!-- 제목 : [FEAT] 구현한 기능 -->
<!-- #[이슈 번호] -->

## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
CORS 설정을 적용하고, 프론트엔드에서 오는 OPTIONS 요청(preflight)에 대한 허용을 보장하기 위한 통합 테스트를 작성했습니다.
- Spring Security 인가 설정에 OPTIONS 요청 허용 추가
```java
.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
```
- 테스트 코드 추가 (SpringBootTest + MockMvc 기반)
  - OPTIONS 요청에 대해 허용 응답 헤더 검증
  - 현재 테스트에 프론트 배포는 'https://web-1-2-pitching-mate-fe.vercel.app' 로 반영되어 있음
- AuthController와 단위테스트는 로그인 URI 가독성을 위해 리다이렉트 처리된 것입니다. 참고해주세요.