### PR TITLE
feat: 인기, 최신 테마 조회 api 구현 및 테마 통계 갱신 로직 리팩토링

### DIFF
--- a/src/main/java/com/ddobang/backend/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/ddobang/backend/domain/diary/service/DiaryService.java
@@ -106,14 +106,19 @@ public class DiaryService {
 
 		DiaryConverter.modifyDiary(theme, diary, diaryRequestDto, elapsedTime);
 
+		diaryRepository.flush();
+		themeStatCalculator.updateThemeStat(theme);
+
 		return DiaryDto.of(diary);
 	}
 
 	@Transactional
 	public void delete(long id) {
 		Diary diary = findById(id);
+		Theme theme = diary.getTheme();
 
 		diaryRepository.delete(diary);
+		themeStatCalculator.updateThemeStat(theme);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/ddobang/backend/domain/stat/calculator/ThemeStatCalculator.java
+++ b/src/main/java/com/ddobang/backend/domain/stat/calculator/ThemeStatCalculator.java
@@ -1,8 +1,10 @@
 package com.ddobang.backend.domain.stat.calculator;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.ddobang.backend.domain.diary.entity.DiaryStat;
 import com.ddobang.backend.domain.diary.repository.DiaryStatRepository;
@@ -20,31 +22,57 @@ public class ThemeStatCalculator {
 	private final DiaryStatRepository diaryStatRepository;
 	private final ThemeStatRepository themeStatRepository;
 
+	@Transactional
 	public void updateThemeStat(Theme theme) {
-		List<DiaryStat> diaryStats = diaryStatRepository.findByThemeId(theme.getId());
-		ThemeStatResult stats = calculateThemeStat(theme, diaryStats);
+		Long themeId = theme.getId();
+		List<DiaryStat> diaryStats = diaryStatRepository.findByThemeId(themeId);
+		ThemeStatResult stats = calculateThemeStat(diaryStats);
+		Optional<ThemeStat> themeStat = themeStatRepository.findById(themeId);
 
-		ThemeStat themeStat = ThemeStat.builder()
-			.theme(theme)
-			.difficulty(stats.difficultyAvg())
-			.fear(stats.fearAvg())
-			.activity(stats.activityAvg())
-			.satisfaction(stats.satisfactionAvg())
-			.production(stats.productionAvg())
-			.story(stats.storyAvg())
-			.question(stats.questionAvg())
-			.interior(stats.interiorAvg())
-			.deviceRatio(stats.deviceRatioAvg())
-			.noHintEscapeRate(stats.noHintEscapeRate())
-			.escapeResult(stats.escapedRate())
-			.escapeTimeAvg(stats.escapeTimeAvg())
-			.build();
+		// 해당 테마에 대한 일지가 없을 경우 통계 삭제
+		if (diaryStats.isEmpty()) {
+			themeStat.ifPresent(themeStatRepository::delete);
+			return;
+		}
 
-		themeStatRepository.save(themeStat);
+		// 해당 테마에 대한 통계가 없을 경우 통계 생성
+		if (themeStat.isPresent()) {
+			themeStat.get().updateStat(
+				stats.difficultyAvg(),
+				stats.fearAvg(),
+				stats.activityAvg(),
+				stats.satisfactionAvg(),
+				stats.productionAvg(),
+				stats.storyAvg(),
+				stats.questionAvg(),
+				stats.interiorAvg(),
+				stats.deviceRatioAvg(),
+				stats.noHintEscapeRate(),
+				stats.escapedRate(),
+				stats.escapeTimeAvg(),
+				diaryStats.size());
+		} else {
+			themeStatRepository.save(ThemeStat.builder()
+				.theme(theme)
+				.difficulty(stats.difficultyAvg())
+				.fear(stats.fearAvg())
+				.activity(stats.activityAvg())
+				.satisfaction(stats.satisfactionAvg())
+				.production(stats.productionAvg())
+				.story(stats.storyAvg())
+				.question(stats.questionAvg())
+				.interior(stats.interiorAvg())
+				.deviceRatio(stats.deviceRatioAvg())
+				.noHintEscapeRate(stats.noHintEscapeRate())
+				.escapeResult(stats.escapedRate())
+				.escapeTimeAvg(stats.escapeTimeAvg())
+				.diaryCount(diaryStats.size())
+				.build());
+		}
 	}
 
 	// 테마 평가 및 통계 계산 메서드(힌트 갯수, 장치 비율 제외 0은 계산에서 제외합니다.)
-	private ThemeStatResult calculateThemeStat(Theme theme, List<DiaryStat> diaryStats) {
+	private ThemeStatResult calculateThemeStat(List<DiaryStat> diaryStats) {
 		long totalCount = diaryStats.size();
 
 		long totalDifficulty = 0;

--- a/src/main/java/com/ddobang/backend/domain/theme/controller/ThemeController.java
+++ b/src/main/java/com/ddobang/backend/domain/theme/controller/ThemeController.java
@@ -81,4 +81,24 @@ public class ThemeController {
 
 		return ResponseFactory.ok(themeTags);
 	}
+
+	@Operation(summary = "태그별 인기 테마 Top 10 조회 api")
+	@GetMapping("/popular")
+	ResponseEntity<SuccessResponse<List<ThemesResponse>>> getPopularThemes(
+		@RequestParam String tagName
+	) {
+		List<ThemesResponse> popularThemes = themeService.getPopularThemesByTagName(tagName);
+
+		return ResponseFactory.ok(popularThemes);
+	}
+
+	@Operation(summary = "태그별 최신 테마 Top 10 조회 api")
+	@GetMapping("/newest")
+	ResponseEntity<SuccessResponse<List<ThemesResponse>>> getNewestThemes(
+		@RequestParam String tagName
+	) {
+		List<ThemesResponse> newestThemes = themeService.getNewestThemesByTagName(tagName);
+
+		return ResponseFactory.ok(newestThemes);
+	}
 }

--- a/src/main/java/com/ddobang/backend/domain/theme/entity/ThemeStat.java
+++ b/src/main/java/com/ddobang/backend/domain/theme/entity/ThemeStat.java
@@ -65,12 +65,12 @@ public class ThemeStat {
 	private int escapeResult;
 	private int escapeTimeAvg;
 
-	private int diaryCount = 0;
+	private int diaryCount;
 
 	@Builder
 	public ThemeStat(Theme theme, float difficulty, float fear, float activity, float satisfaction, float production,
 		float story, float question, float interior, float deviceRatio, int noHintEscapeRate, int escapeResult,
-		int escapeTimeAvg) {
+		int escapeTimeAvg, int diaryCount) {
 		this.theme = theme;
 		this.difficulty = difficulty;
 		this.fear = fear;
@@ -84,15 +84,25 @@ public class ThemeStat {
 		this.noHintEscapeRate = noHintEscapeRate;
 		this.escapeResult = escapeResult;
 		this.escapeTimeAvg = escapeTimeAvg;
+		this.diaryCount = diaryCount;
 	}
 
-	public void incrementDiaryCount() {
-		diaryCount++;
-	}
-
-	public void decrementDiaryCount() {
-		if (diaryCount > 0) {
-			diaryCount--;
-		}
+	public void updateStat(float difficulty, float fear, float activity, float satisfaction, float production,
+		float story,
+		float question, float interior, float deviceRatio, int noHintEscapeRate, int escapeResult, int escapeTimeAvg,
+		int diaryCount) {
+		this.difficulty = difficulty;
+		this.fear = fear;
+		this.activity = activity;
+		this.satisfaction = satisfaction;
+		this.production = production;
+		this.story = story;
+		this.question = question;
+		this.interior = interior;
+		this.deviceRatio = deviceRatio;
+		this.noHintEscapeRate = noHintEscapeRate;
+		this.escapeResult = escapeResult;
+		this.escapeTimeAvg = escapeTimeAvg;
+		this.diaryCount = diaryCount;
 	}
 }

--- a/src/main/java/com/ddobang/backend/domain/theme/entity/ThemeStat.java
+++ b/src/main/java/com/ddobang/backend/domain/theme/entity/ThemeStat.java
@@ -65,6 +65,8 @@ public class ThemeStat {
 	private int escapeResult;
 	private int escapeTimeAvg;
 
+	private int diaryCount = 0;
+
 	@Builder
 	public ThemeStat(Theme theme, float difficulty, float fear, float activity, float satisfaction, float production,
 		float story, float question, float interior, float deviceRatio, int noHintEscapeRate, int escapeResult,
@@ -82,5 +84,15 @@ public class ThemeStat {
 		this.noHintEscapeRate = noHintEscapeRate;
 		this.escapeResult = escapeResult;
 		this.escapeTimeAvg = escapeTimeAvg;
+	}
+
+	public void incrementDiaryCount() {
+		diaryCount++;
+	}
+
+	public void decrementDiaryCount() {
+		if (diaryCount > 0) {
+			diaryCount--;
+		}
 	}
 }

--- a/src/main/java/com/ddobang/backend/domain/theme/repository/ThemeRepositoryCustom.java
+++ b/src/main/java/com/ddobang/backend/domain/theme/repository/ThemeRepositoryCustom.java
@@ -17,4 +17,8 @@ public interface ThemeRepositoryCustom {
 	List<Theme> findThemesForPartySearch(String keyword);
 
 	List<SimpleThemeResponse> findThemesForAdminSearch(ThemeFilterRequest request, int page, int size);
+
+	List<Theme> findTop10PopularThemesByTagName(String tagName);
+
+	List<Theme> findTop10NewestThemesByTagName(String tagName);
 }

--- a/src/main/java/com/ddobang/backend/domain/theme/repository/ThemeRepositoryImpl.java
+++ b/src/main/java/com/ddobang/backend/domain/theme/repository/ThemeRepositoryImpl.java
@@ -110,7 +110,6 @@ public class ThemeRepositoryImpl implements ThemeRepositoryCustom {
 					.desc()
 			)
 			.limit(10)
-			.distinct()
 			.fetch();
 
 		return themeStats.stream()
@@ -130,7 +129,6 @@ public class ThemeRepositoryImpl implements ThemeRepositoryCustom {
 			.where(condition)
 			.orderBy(theme.createdAt.desc())
 			.limit(10)
-			.distinct()
 			.fetch();
 	}
 

--- a/src/main/java/com/ddobang/backend/domain/theme/repository/ThemeRepositoryImpl.java
+++ b/src/main/java/com/ddobang/backend/domain/theme/repository/ThemeRepositoryImpl.java
@@ -9,9 +9,11 @@ import com.ddobang.backend.domain.store.entity.QStore;
 import com.ddobang.backend.domain.theme.dto.request.ThemeFilterRequest;
 import com.ddobang.backend.domain.theme.dto.response.SimpleThemeResponse;
 import com.ddobang.backend.domain.theme.entity.QTheme;
+import com.ddobang.backend.domain.theme.entity.QThemeStat;
 import com.ddobang.backend.domain.theme.entity.QThemeTag;
 import com.ddobang.backend.domain.theme.entity.QThemeTagMapping;
 import com.ddobang.backend.domain.theme.entity.Theme;
+import com.ddobang.backend.domain.theme.entity.ThemeStat;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.JPAExpressions;
@@ -35,6 +37,7 @@ public class ThemeRepositoryImpl implements ThemeRepositoryCustom {
 	private static final QRegion region = QRegion.region;
 	private static final QThemeTagMapping mapping = QThemeTagMapping.themeTagMapping;
 	private static final QThemeTag tag = QThemeTag.themeTag;
+	private static final QThemeStat themeStat = QThemeStat.themeStat;
 
 	@Override
 	public List<Theme> findThemesByFilter(ThemeFilterRequest request, int page, int size) {
@@ -86,6 +89,48 @@ public class ThemeRepositoryImpl implements ThemeRepositoryCustom {
 			.orderBy(theme.name.asc())
 			.offset((long)page * size)
 			.limit(size + 1) // size보다 1개 더 가져와서 hasNext 판단
+			.fetch();
+	}
+
+	@Override
+	public List<Theme> findTop10PopularThemesByTagName(String tagName) {
+		BooleanBuilder condition = buildForLandingConditions(tagName);
+
+		List<ThemeStat> themeStats = queryFactory
+			.select(themeStat)
+			.from(themeStat)
+			.join(themeStat.theme, theme).fetchJoin()
+			.leftJoin(theme.store, store).fetchJoin()
+			.leftJoin(theme.themeTagMappings, mapping).fetchJoin()
+			.leftJoin(mapping.themeTag, tag).fetchJoin()
+			.where(condition)
+			.orderBy(
+				themeStat.diaryCount.multiply(7)
+					.add(themeStat.satisfaction.multiply(3))
+					.desc()
+			)
+			.limit(10)
+			.distinct()
+			.fetch();
+
+		return themeStats.stream()
+			.map(ThemeStat::getTheme)
+			.toList();
+	}
+
+	@Override
+	public List<Theme> findTop10NewestThemesByTagName(String tagName) {
+		BooleanBuilder condition = buildForLandingConditions(tagName);
+
+		return queryFactory
+			.selectFrom(theme)
+			.join(theme.store, store).fetchJoin()
+			.leftJoin(theme.themeTagMappings, mapping).fetchJoin()
+			.leftJoin(mapping.themeTag, tag).fetchJoin()
+			.where(condition)
+			.orderBy(theme.createdAt.desc())
+			.limit(10)
+			.distinct()
 			.fetch();
 	}
 
@@ -144,7 +189,6 @@ public class ThemeRepositoryImpl implements ThemeRepositoryCustom {
 
 		if (keyword != null && !keyword.isBlank()) {
 			builder.and(
-
 				theme.name.containsIgnoreCase(keyword)
 					.or(store.name.containsIgnoreCase(keyword))        //알파벳 대소문자 구분x
 			);
@@ -152,4 +196,28 @@ public class ThemeRepositoryImpl implements ThemeRepositoryCustom {
 
 		return builder;
 	}
+
+	private BooleanBuilder buildForLandingConditions(String tagName) {
+		BooleanBuilder builder = new BooleanBuilder();
+		builder.and(theme.status.eq(Theme.Status.OPENED));
+
+		if (tagName != null && !tagName.isBlank()) {
+			QThemeTagMapping subMapping = new QThemeTagMapping("subMapping");
+			QThemeTag subTag = new QThemeTag("subTag");
+
+			builder.and(JPAExpressions
+				.selectOne()    // 존재 여부만 판단
+				.from(subMapping)
+				.join(subMapping.themeTag, subTag)    // 테마 태그에 조인
+				.where(
+					subMapping.theme.eq(theme),    // 지금 조회 중인 테마와 매핑된 태그인지 확인
+					subTag.name.eq(tagName)    // 사용자가 요청한 필터에 포함되는 태그인지 확인
+				)
+				.exists()    // where 조건 만족 시 true
+			);
+		}
+
+		return builder;
+	}
+
 }

--- a/src/main/java/com/ddobang/backend/domain/theme/service/ThemeService.java
+++ b/src/main/java/com/ddobang/backend/domain/theme/service/ThemeService.java
@@ -168,6 +168,6 @@ public class ThemeService {
 	@Scheduled(cron = "0 0 0 * * *") // 매일 자정에 실행
 	@CacheEvict(cacheNames = {"popularThemesByTag", "newestThemesByTag"}, allEntries = true)
 	public void clearThemeCachesDaily() {
-		log.warn("매일 자정 캐시 초기화: 인기 테마 / 최신 테마 캐시 삭제 완료");
+		log.info("매일 자정 캐시 초기화: 인기 테마 / 최신 테마 캐시 삭제 완료");
 	}
 }

--- a/src/main/java/com/ddobang/backend/domain/theme/service/ThemeService.java
+++ b/src/main/java/com/ddobang/backend/domain/theme/service/ThemeService.java
@@ -3,6 +3,9 @@ package com.ddobang.backend.domain.theme.service;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,7 +31,9 @@ import com.ddobang.backend.domain.theme.repository.ThemeStatRepository;
 import com.ddobang.backend.global.response.SliceDto;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ThemeService {
@@ -139,7 +144,30 @@ public class ThemeService {
 		return themeTagService.getAllTags();
 	}
 
+	@Transactional(readOnly = true)
 	public ThemeStat getThemeStatById(Long id) {
 		return themeStatRepository.findById(id).orElse(null);
+	}
+
+	@Cacheable(cacheNames = "popularThemesByTag", key = "#tagName")
+	@Transactional(readOnly = true)
+	public List<ThemesResponse> getPopularThemesByTagName(String tagName) {
+		List<Theme> themes = themeRepository.findTop10PopularThemesByTagName(tagName);
+
+		return themes.stream().map(ThemesResponse::of).toList();
+	}
+
+	@Cacheable(cacheNames = "newestThemesByTag", key = "#tagName")
+	@Transactional(readOnly = true)
+	public List<ThemesResponse> getNewestThemesByTagName(String tagName) {
+		List<Theme> themes = themeRepository.findTop10NewestThemesByTagName(tagName);
+
+		return themes.stream().map(ThemesResponse::of).toList();
+	}
+
+	@Scheduled(cron = "0 0 0 * * *") // 매일 자정에 실행
+	@CacheEvict(cacheNames = {"popularThemesByTag", "newestThemesByTag"}, allEntries = true)
+	public void clearThemeCachesDaily() {
+		log.warn("매일 자정 캐시 초기화: 인기 테마 / 최신 테마 캐시 삭제 완료");
 	}
 }

--- a/src/main/java/com/ddobang/backend/global/config/CacheConfig.java
+++ b/src/main/java/com/ddobang/backend/global/config/CacheConfig.java
@@ -1,0 +1,14 @@
+package com.ddobang.backend.global.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * CacheConfig
+ * 캐싱에 관련된 설정
+ * @author 100minha
+ */
+@EnableCaching
+@Configuration
+public class CacheConfig {
+}

--- a/src/main/java/com/ddobang/backend/global/config/ScheduleConfig.java
+++ b/src/main/java/com/ddobang/backend/global/config/ScheduleConfig.java
@@ -1,0 +1,14 @@
+package com.ddobang.backend.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * ScheduleConfig
+ * 스케줄링 설정
+ * @author 100minha
+ */
+@EnableScheduling
+@Configuration
+public class ScheduleConfig {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,17 +16,6 @@ spring:
     async:
       request-timeout: 600000  # SSE 연결 타임아웃 설정 (밀리초)
 
-  # h2
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
-  datasource:
-    url: jdbc:h2:./db_dev;MODE=MySQL
-    driverClassName: org.h2.Driver
-    username: sa
-    password: ""
-
   # JPA
   jpa:
     hibernate:

--- a/src/test/java/com/ddobang/backend/domain/diary/service/DiaryServiceTest.java
+++ b/src/test/java/com/ddobang/backend/domain/diary/service/DiaryServiceTest.java
@@ -1,0 +1,129 @@
+package com.ddobang.backend.domain.diary.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ddobang.backend.domain.diary.dto.request.DiaryRequestDto;
+import com.ddobang.backend.domain.theme.entity.ThemeStat;
+import com.ddobang.backend.domain.theme.repository.ThemeStatRepository;
+
+/**
+ * DiaryServiceTest
+ * 일지 서비스 리포지토리 통합 테스트
+ * @author 100minha
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class DiaryServiceTest {
+
+	@Autowired
+	private DiaryService diaryService;
+	@Autowired
+	private ThemeStatRepository themeStatRepository;
+
+	int diaryCount;
+
+	@BeforeEach
+	void setUp() {
+		diaryCount = themeStatRepository.findById(1L).get().getDiaryCount();
+	}
+
+	@Test
+	@DisplayName("일지 작성 시 기존 테마 통계 업데이트(더티체킹) 테스트")
+	void t1() {
+		// given
+		Long themeId = 1L;
+
+		// when
+		diaryService.write(
+			DiaryRequestDto.builder()
+				.themeId(themeId)
+				.escapeDate(LocalDate.of(2024, 1, 15))
+				.participants("지인1, 지인2")
+				.difficulty(1)
+				.fear(1)
+				.activity(1)
+				.satisfaction(1)
+				.production(1)
+				.story(1)
+				.question(1)
+				.interior(1)
+				.deviceRatio(50)
+				.hintCount(1)
+				.escapeResult(true)
+				.timeType("REMAINING")
+				.elapsedTime("15:25")
+				.review("너무 재밌었다!!")
+				.build()
+		);
+		ThemeStat updatedThemeStat = themeStatRepository.findById(themeId).get();
+
+		// then
+		assertThat(updatedThemeStat.getDiaryCount()).isEqualTo(diaryCount + 1);
+		assertThat(updatedThemeStat.getDeviceRatio()).isEqualTo(60);
+		assertThat(updatedThemeStat.getEscapeResult()).isEqualTo(50);
+		assertThat(updatedThemeStat.getSatisfaction()).isEqualTo(2);
+	}
+
+	@Test
+	@DisplayName("일지 수정 시 테마 통계 업데이트(더티체킹) 테스트")
+	void t2() {
+		// given
+		Long themeId = 1L;
+
+		// when
+		diaryService.modify(
+			1L,
+			DiaryRequestDto.builder()
+				.themeId(themeId)
+				.escapeDate(LocalDate.of(2024, 1, 15))
+				.participants("지인1, 지인2")
+				.difficulty(1)
+				.fear(1)
+				.activity(1)
+				.satisfaction(1)
+				.production(1)
+				.story(1)
+				.question(1)
+				.interior(1)
+				.deviceRatio(50)
+				.hintCount(1)
+				.escapeResult(true)
+				.timeType("REMAINING")
+				.elapsedTime("15:25")
+				.review("너무 재밌었다!!")
+				.build()
+		);
+		ThemeStat updatedThemeStat = themeStatRepository.findById(themeId).get();
+
+		// then
+		assertThat(updatedThemeStat.getDiaryCount()).isEqualTo(1);
+		assertThat(updatedThemeStat.getEscapeResult()).isEqualTo(100);
+		assertThat(updatedThemeStat.getSatisfaction()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("일지 삭제 시 테마 통계 업데이트(더티체킹) 테스트")
+	void t3() {
+		// given
+		Long id = 1L;
+
+		// when
+		diaryService.delete(id);
+		Optional<ThemeStat> updatedThemeStat = themeStatRepository.findById(id);
+
+		// then
+		assertThat(updatedThemeStat.isPresent()).isFalse();
+	}
+}

--- a/src/test/java/com/ddobang/backend/domain/theme/controller/ThemeControllerTest.java
+++ b/src/test/java/com/ddobang/backend/domain/theme/controller/ThemeControllerTest.java
@@ -46,7 +46,6 @@ public class ThemeControllerTest {
 
 	@Autowired
 	private BaseInitData initThemeMockData;
-	//private InitThemeMockData initThemeMockData;
 
 	@Autowired
 	private ThemeStatRepository themeStatRepository;
@@ -485,5 +484,87 @@ public class ThemeControllerTest {
 			.andExpect(jsonPath("$.data.length()").value(3))
 			.andExpect(jsonPath("$.data[0].name").value(tag1.getName()))
 			.andExpect(jsonPath("$.data[2].name").value(tag3.getName()));
+	}
+
+	@Test
+	@DisplayName("인기 테마 조회 테스트")
+	void getTop10PopularThemesByTagNameTest() throws Exception {
+		// given
+		String tagName = tag1.getName();
+
+		// when
+		ResultActions result = mvc.perform(get("/api/v1/themes/popular")
+			.param("tagName", tagName)
+			.contentType(MediaType.APPLICATION_JSON)
+		);
+
+		// then
+		result
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.length()").value(4))
+			.andExpect(jsonPath("$.data[0].name").value(themes.get(0).getName()))
+			.andExpect(jsonPath("$.data[0].tags[0]").value(tag1.getName()))
+			.andExpect(jsonPath("$.data[0].tags[1]").value(tag2.getName()))
+			.andExpect(jsonPath("$.data[1].name").value(themes.get(1).getName()))
+			.andExpect(jsonPath("$.data[1].recommendedParticipants").value("2~3인"))
+			.andExpect(jsonPath("$.data[2].name").value(themes.get(4).getName()));
+	}
+
+	@Test
+	@DisplayName("없는 태그로 인기 테마 조회 테스트")
+	void getTop10PopularThemesByInvalidTagNameTest() throws Exception {
+		// given
+		String tagName = "INVALID_TAG";
+
+		// when
+		ResultActions result = mvc.perform(get("/api/v1/themes/popular")
+			.param("tagName", tagName)
+			.contentType(MediaType.APPLICATION_JSON)
+		);
+
+		// then
+		result
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.length()").value(0));
+	}
+
+	@Test
+	@DisplayName("최신 테마 조회 테스트")
+	void getTop10NewestThemesByTagNameTest() throws Exception {
+		// given
+		String tagName = tag3.getName();
+
+		// when
+		ResultActions result = mvc.perform(get("/api/v1/themes/newest")
+			.param("tagName", tagName)
+			.contentType(MediaType.APPLICATION_JSON)
+		);
+
+		// then
+		result
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.length()").value(2))
+			.andExpect(jsonPath("$.data[0].name").value(themes.get(7).getName()))
+			.andExpect(jsonPath("$.data[0].tags[0]").value(tag3.getName()))
+			.andExpect(jsonPath("$.data[1].name").value(themes.get(3).getName()))
+			.andExpect(jsonPath("$.data[1].recommendedParticipants").value("2~3인"));
+	}
+
+	@Test
+	@DisplayName("없는 태그로 최신 테마 조회 테스트")
+	void getTop10NewestThemesByInvalidTagNameTest() throws Exception {
+		// given
+		String tagName = "INVALID_TAG";
+
+		// when
+		ResultActions result = mvc.perform(get("/api/v1/themes/newest")
+			.param("tagName", tagName)
+			.contentType(MediaType.APPLICATION_JSON)
+		);
+
+		// then
+		result
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.length()").value(0));
 	}
 }

--- a/src/test/java/com/ddobang/backend/domain/theme/repository/ThemeRepositoryTest.java
+++ b/src/test/java/com/ddobang/backend/domain/theme/repository/ThemeRepositoryTest.java
@@ -98,13 +98,9 @@ public class ThemeRepositoryTest {
 				.noHintEscapeRate(80)
 				.escapeResult(60)
 				.escapeTimeAvg(3600)
+				.diaryCount(5 / j)
 				.build()));
-			themeStats.get(j - 1)
-				.incrementDiaryCount();
 		}
-
-		themeStats.get(1).incrementDiaryCount();
-		//themeStatRepository.saveAll(themeStats);
 	}
 
 	@Test
@@ -333,9 +329,9 @@ public class ThemeRepositoryTest {
 
 		// then
 		assertThat(results).hasSize(5);
-		assertThat(results.get(0)).isEqualTo(testThemes.get(4));
-		assertThat(results.get(1)).isEqualTo(testThemes.get(1));
-		assertThat(results.get(2)).isEqualTo(testThemes.get(3));
+		assertThat(results.get(0)).isEqualTo(testThemes.get(0));
+		assertThat(results.get(1)).isEqualTo(testThemes.get(4));
+		assertThat(results.get(2)).isEqualTo(testThemes.get(1));
 	}
 
 	@Test

--- a/src/test/java/com/ddobang/backend/domain/theme/repository/ThemeRepositoryTest.java
+++ b/src/test/java/com/ddobang/backend/domain/theme/repository/ThemeRepositoryTest.java
@@ -20,6 +20,7 @@ import com.ddobang.backend.domain.store.repository.StoreRepository;
 import com.ddobang.backend.domain.theme.dto.request.ThemeFilterRequest;
 import com.ddobang.backend.domain.theme.dto.response.SimpleThemeResponse;
 import com.ddobang.backend.domain.theme.entity.Theme;
+import com.ddobang.backend.domain.theme.entity.ThemeStat;
 import com.ddobang.backend.domain.theme.entity.ThemeTag;
 import com.ddobang.backend.global.config.JpaAuditingConfig;
 import com.ddobang.backend.global.config.QuerydslConfig;
@@ -42,6 +43,8 @@ public class ThemeRepositoryTest {
 	@Autowired
 	private ThemeTagRepository themeTagRepository;
 	@Autowired
+	private ThemeStatRepository themeStatRepository;
+	@Autowired
 	private StoreRepository storeRepository;
 
 	@PersistenceContext
@@ -56,6 +59,7 @@ public class ThemeRepositoryTest {
 	private ThemeTag tag2 = new ThemeTag("태그2");
 
 	private List<Theme> testThemes = new ArrayList<>();
+	private List<ThemeStat> themeStats = new ArrayList<>();
 
 	@BeforeEach
 	void setUp() {
@@ -78,6 +82,29 @@ public class ThemeRepositoryTest {
 				.thumbnailUrl("test.thumbnail")
 				.build()));
 		}
+
+		for (int j = 1; j <= 5; j++) {
+			themeStats.add(themeStatRepository.save(ThemeStat.builder()
+				.theme(testThemes.get(j - 1))
+				.difficulty(3)
+				.fear(2)
+				.activity(4)
+				.satisfaction(j)
+				.production(3)
+				.story(4)
+				.question(3)
+				.interior(4)
+				.deviceRatio(75)
+				.noHintEscapeRate(80)
+				.escapeResult(60)
+				.escapeTimeAvg(3600)
+				.build()));
+			themeStats.get(j - 1)
+				.incrementDiaryCount();
+		}
+
+		themeStats.get(1).incrementDiaryCount();
+		//themeStatRepository.saveAll(themeStats);
 	}
 
 	@Test
@@ -295,5 +322,60 @@ public class ThemeRepositoryTest {
 		assertThat(results).hasSize(0);
 	}
 
-	// TODO: Column 제약조건 별 저장 테스트 추가
+	@Test
+	@DisplayName("인기 테마 조회 테스트")
+	void findTop10PopularThemesByTagNameTest() {
+		// given
+		String tagName = tag1.getName();
+
+		// when
+		List<Theme> results = themeRepository.findTop10PopularThemesByTagName(tagName);
+
+		// then
+		assertThat(results).hasSize(5);
+		assertThat(results.get(0)).isEqualTo(testThemes.get(4));
+		assertThat(results.get(1)).isEqualTo(testThemes.get(1));
+		assertThat(results.get(2)).isEqualTo(testThemes.get(3));
+	}
+
+	@Test
+	@DisplayName("없는 태그로 인기 테마 조회 테스트")
+	void findTop10PopularThemesByInvalidTagNameTest() {
+		// given
+		String tagName = "INVALID_TAG";
+
+		// when
+		List<Theme> results = themeRepository.findTop10PopularThemesByTagName(tagName);
+
+		// then
+		assertThat(results.isEmpty()).isTrue();
+	}
+
+	@Test
+	@DisplayName("최신 테마 조회 테스트")
+	void findTop10NewestThemesByTagNameTest() {
+		// given
+		String tagName = tag1.getName();
+
+		// when
+		List<Theme> results = themeRepository.findTop10NewestThemesByTagName(tagName);
+
+		// then
+		assertThat(results).hasSize(5);
+		assertThat(results.get(0)).isIn(testThemes);
+		assertThat(results.get(2)).isIn(testThemes);
+	}
+
+	@Test
+	@DisplayName("없는 태그로 최신 테마 조회 테스트")
+	void findTop10NewestThemesByInvalidTagNameTest() {
+		// given
+		String tagName = "INVALID_TAG";
+
+		// when
+		List<Theme> results = themeRepository.findTop10NewestThemesByTagName(tagName);
+
+		// then
+		assertThat(results.isEmpty()).isTrue();
+	}
 }


### PR DESCRIPTION
<!-- 제목 : [FEAT] 구현한 기능 -->
# feat: 인기, 최신 테마 조회 api 구현 및 테마 통계 갱신 로직 리팩토링
<!-- #[이슈 번호] -->
#94 

## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [ ] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용

- [ ] 태그별 인기 테마(TOP10) 조회 api 구현
  - 선정 기준 : (일지 갯수 * 7) + (만족도 * 3)
 
- [ ] 태그별  최신 테마(TOP10) 조회 api 구현
- [ ] 테마 통계 갱신 로직 리팩토링
  - 일지에 대한 등록, 수정, 삭제가 이루어질 때 마다 갱신
  - 한 테마에 대한 통계는 1개만 존재하며, 일지가 1개도 없으면 테마 통계까지 삭제

- [ ] 구현 및 리팩토링한 기능들에 대한 테스트 코드 작성