### PR TITLE
fix: JWT 토큰 구조 변경 및 OAuth2 회원 조회 로직 수정

### DIFF
--- a/src/main/java/com/ddobang/backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/ddobang/backend/domain/member/repository/MemberRepository.java
@@ -9,7 +9,7 @@ import com.ddobang.backend.domain.member.entity.Member;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
-	Optional<Member> findByKakaoId(String kakaoId);
+	Member findByKakaoId(String kakaoId);
 
 	boolean existsByKakaoId(String kakaoId);
 

--- a/src/main/java/com/ddobang/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/ddobang/backend/domain/member/service/MemberService.java
@@ -2,7 +2,6 @@ package com.ddobang.backend.domain.member.service;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
@@ -67,7 +66,7 @@ public class MemberService {
 		return OtherProfileResponse.of(member);
 	}
 
-	public Optional<Member> getByKakaoId(String kakaoId) {
+	public Member getByKakaoId(String kakaoId) {
 		return memberRepository.findByKakaoId(kakaoId);
 	}
 

--- a/src/main/java/com/ddobang/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/ddobang/backend/domain/member/service/MemberService.java
@@ -67,7 +67,7 @@ public class MemberService {
 		return OtherProfileResponse.of(member);
 	}
 
-	public Optional<Member> findByKakaoId(String kakaoId) {
+	public Optional<Member> getByKakaoId(String kakaoId) {
 		return memberRepository.findByKakaoId(kakaoId);
 	}
 

--- a/src/main/java/com/ddobang/backend/global/auth/service/AuthService.java
+++ b/src/main/java/com/ddobang/backend/global/auth/service/AuthService.java
@@ -29,11 +29,11 @@ public class AuthService {
 	/**
 	 * 로그인 성공 시 액세스 / 리프레시 토큰 생성 및 쿠키에 저장
 	 */
-	public void handleLoginSuccess(HttpServletResponse response, String kakaoId) {
+	public void handleLoginSuccess(HttpServletResponse response, Member member) {
 		boolean isAdmin = false;
 
-		String accessToken = jwtTokenProvider.generateToken(kakaoId, JwtTokenType.ACCESS, isAdmin);
-		String refreshToken = jwtTokenProvider.generateToken(kakaoId, JwtTokenType.REFRESH, isAdmin);
+		String accessToken = jwtTokenProvider.generateToken(member, JwtTokenType.ACCESS, isAdmin);
+		String refreshToken = jwtTokenProvider.generateToken(member, JwtTokenType.REFRESH, isAdmin);
 
 		response.addCookie(CookieUtil.createAccessTokenCookie(accessToken));
 		response.addCookie(CookieUtil.createRefreshTokenCookie(refreshToken));
@@ -47,7 +47,7 @@ public class AuthService {
 			throw new OAuth2Exception(OAuth2ErrorCode.OAUTH2_MISSING_ID);
 		}
 
-		String signupToken = jwtTokenProvider.generateToken(kakaoId, JwtTokenType.SIGNUP, false);
+		String signupToken = jwtTokenProvider.generateSignupToken(kakaoId);
 		response.addCookie(CookieUtil.createSignupTokenCookie(signupToken));
 	}
 
@@ -66,8 +66,8 @@ public class AuthService {
 		Member member = memberService.registerMember(kakaoId, request);
 
 		// 엑세스 / 리프레시 토큰 발급
-		String accessToken = jwtTokenProvider.generateToken(member.getNickname(), JwtTokenType.ACCESS, false);
-		String refreshToken = jwtTokenProvider.generateToken(member.getNickname(), JwtTokenType.REFRESH, false);
+		String accessToken = jwtTokenProvider.generateToken(member, JwtTokenType.ACCESS, false);
+		String refreshToken = jwtTokenProvider.generateToken(member, JwtTokenType.REFRESH, false);
 
 		// 쿠키에 저장
 		response.addCookie(CookieUtil.createAccessTokenCookie(accessToken));

--- a/src/main/java/com/ddobang/backend/global/security/LoginMemberProvider.java
+++ b/src/main/java/com/ddobang/backend/global/security/LoginMemberProvider.java
@@ -5,7 +5,9 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 import com.ddobang.backend.domain.member.entity.Member;
-import com.ddobang.backend.domain.member.service.MemberService;
+import com.ddobang.backend.domain.member.exception.MemberErrorCode;
+import com.ddobang.backend.domain.member.exception.MemberException;
+import com.ddobang.backend.domain.member.repository.MemberRepository;
 import com.ddobang.backend.global.exception.jwt.JwtErrorCode;
 import com.ddobang.backend.global.exception.jwt.JwtException;
 
@@ -19,7 +21,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class LoginMemberProvider {
 
-	private final MemberService memberService;
+	private final MemberRepository memberRepository;
 
 	public Member getCurrentMember() {
 		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
@@ -30,6 +32,7 @@ public class LoginMemberProvider {
 		}
 
 		// 로그인한 사용자의 ID로 회원 객체를 조회
-		return memberService.getById(userDetails.memberId());
+		return memberRepository.findById(userDetails.memberId())
+			.orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 	}
 }

--- a/src/main/java/com/ddobang/backend/global/security/SecurityConfig.java
+++ b/src/main/java/com/ddobang/backend/global/security/SecurityConfig.java
@@ -46,7 +46,9 @@ public class SecurityConfig {
 			.authorizeHttpRequests(auth -> {
 				auth
 					// OAuth2 로그인 관련
-					.requestMatchers("/oauth2/authorization/**", "/login/oauth2/code/**").permitAll()
+					.requestMatchers("/oauth2/authorization/**", "/login/oauth2/code/**").permitAll() // OAuth2 로그인 관련
+					.requestMatchers("/signup", "/api/v1/auth/signup").permitAll() // 회원가입 페이지
+					.requestMatchers("/login", "/api/v1/auth/login").permitAll() // 카카오 로그인 URL
 
 					// Swagger, 오류 페이지
 					.requestMatchers("/error", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**",

--- a/src/main/java/com/ddobang/backend/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ddobang/backend/global/security/jwt/JwtAuthenticationFilter.java
@@ -6,7 +6,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import com.ddobang.backend.domain.member.entity.Member;
 import com.ddobang.backend.domain.member.service.MemberService;
 import com.ddobang.backend.global.exception.jwt.JwtErrorCode;
 import com.ddobang.backend.global.exception.jwt.JwtException;
@@ -45,15 +44,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			String token = jwtTokenProvider.resolveAccessToken(request);
 
 			if (token != null && jwtTokenProvider.isValidToken(token, JwtTokenType.ACCESS)) {
+				Long memberId = Long.valueOf(jwtTokenProvider.getSubject(token)); // sub = memberId
 				String nickname = jwtTokenProvider.extractNickname(token);
-				Member member = memberService.getByNickname(nickname);
+				boolean isAdmin = jwtTokenProvider.extractIsAdmin(token);
 
-				// 비밀번호가 null이 아니고 빈 문자열이 아닐 경우 관리자
-				boolean isAdmin = member.getPassword() != null && !member.getPassword().isBlank();
-
-				// SecurityContext에 인증 정보 저장
-				CustomUserDetails userDetails = new CustomUserDetails(
-					member.getId(), member.getNickname(), isAdmin);
+				CustomUserDetails userDetails = new CustomUserDetails(memberId, nickname, isAdmin);
 
 				UsernamePasswordAuthenticationToken authentication =
 					new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());

--- a/src/main/java/com/ddobang/backend/global/security/jwt/JwtPayloadExtractor.java
+++ b/src/main/java/com/ddobang/backend/global/security/jwt/JwtPayloadExtractor.java
@@ -52,7 +52,7 @@ public class JwtPayloadExtractor {
 	}
 
 	// 주 식별자 추출
-	private String extractSubject(String token) {
-		return getClaims(token).getSubject();
+	public String extractSubject(String token) {
+		return getClaims(token).getSubject(); // sub = memberId
 	}
 }

--- a/src/main/java/com/ddobang/backend/global/security/jwt/JwtTokenFactory.java
+++ b/src/main/java/com/ddobang/backend/global/security/jwt/JwtTokenFactory.java
@@ -5,9 +5,6 @@ import java.util.Date;
 import org.springframework.stereotype.Component;
 
 import com.ddobang.backend.domain.member.entity.Member;
-import com.ddobang.backend.domain.member.exception.MemberErrorCode;
-import com.ddobang.backend.domain.member.exception.MemberException;
-import com.ddobang.backend.domain.member.service.MemberService;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -22,24 +19,29 @@ public class JwtTokenFactory {
 
 	private final JwtTokenProperties jwtTokenProperties;
 	private final JwtSigningKey jwtSigningKey;
-	private final MemberService memberService;
 
-	// JWT 토큰을 생성하는 메서드
-	public String generateToken(String kakaoId, JwtTokenType type, boolean isAdmin) {
-		Member member = memberService.findByKakaoId(kakaoId)
-			.orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+	// 회원가입용: kakaoId 기반
+	public String generateSignupToken(String kakaoId) {
+		return createToken(kakaoId, JwtTokenType.SIGNUP, false, null);
+	}
 
+	// 로그인/인증용: member 기반
+	public String generateToken(Member member, JwtTokenType type, boolean isAdmin) {
+		return createToken(String.valueOf(member.getId()), type, isAdmin, member.getNickname());
+	}
+
+	private String createToken(String subject, JwtTokenType type, boolean isAdmin, String nickname) {
 		long expiration = jwtTokenProperties.getExpiration(type);
 		Date now = new Date();
 		Date expiry = new Date(now.getTime() + expiration);
 
 		return Jwts.builder()
-			.setSubject(String.valueOf(member.getId()))
+			.setSubject(subject)
 			.setIssuedAt(now)
 			.setExpiration(expiry)
-			.claim("nickname", member.getNickname())
 			.claim("type", type.name())
 			.claim("isAdmin", isAdmin)
+			.claim("nickname", nickname)
 			.signWith(jwtSigningKey.getKey(), SignatureAlgorithm.HS256)
 			.compact();
 	}

--- a/src/main/java/com/ddobang/backend/global/security/jwt/JwtTokenFactory.java
+++ b/src/main/java/com/ddobang/backend/global/security/jwt/JwtTokenFactory.java
@@ -4,6 +4,11 @@ import java.util.Date;
 
 import org.springframework.stereotype.Component;
 
+import com.ddobang.backend.domain.member.entity.Member;
+import com.ddobang.backend.domain.member.exception.MemberErrorCode;
+import com.ddobang.backend.domain.member.exception.MemberException;
+import com.ddobang.backend.domain.member.service.MemberService;
+
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import lombok.RequiredArgsConstructor;
@@ -17,17 +22,22 @@ public class JwtTokenFactory {
 
 	private final JwtTokenProperties jwtTokenProperties;
 	private final JwtSigningKey jwtSigningKey;
+	private final MemberService memberService;
 
 	// JWT 토큰을 생성하는 메서드
-	public String generateToken(String subject, JwtTokenType type, boolean isAdmin) {
+	public String generateToken(String kakaoId, JwtTokenType type, boolean isAdmin) {
+		Member member = memberService.findByKakaoId(kakaoId)
+			.orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
 		long expiration = jwtTokenProperties.getExpiration(type);
 		Date now = new Date();
 		Date expiry = new Date(now.getTime() + expiration);
 
 		return Jwts.builder()
-			.setSubject(subject)
+			.setSubject(String.valueOf(member.getId()))
 			.setIssuedAt(now)
 			.setExpiration(expiry)
+			.claim("nickname", member.getNickname())
 			.claim("type", type.name())
 			.claim("isAdmin", isAdmin)
 			.signWith(jwtSigningKey.getKey(), SignatureAlgorithm.HS256)

--- a/src/main/java/com/ddobang/backend/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/ddobang/backend/global/security/jwt/JwtTokenProvider.java
@@ -2,6 +2,8 @@ package com.ddobang.backend.global.security.jwt;
 
 import org.springframework.stereotype.Component;
 
+import com.ddobang.backend.domain.member.entity.Member;
+
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 
@@ -21,6 +23,11 @@ public class JwtTokenProvider {
 	}
 
 	//>>> 토큰 추출 그룹
+	// JWT 토큰에서 주 식별자 추출
+	public String getSubject(String token) {
+		return payloadExtractor.extractSubject(token);
+	}
+
 	// JWT 토큰에서 카카오ID 추출
 	public String extractKakaoId(String token) {
 		return payloadExtractor.extractKakaoId(token);
@@ -42,7 +49,11 @@ public class JwtTokenProvider {
 	}
 
 	//>>> 토큰 생성 그룹
-	public String generateToken(String subject, JwtTokenType type, boolean isAdmin) {
-		return tokenFactory.generateToken(subject, type, isAdmin);
+	public String generateToken(Member member, JwtTokenType type, boolean isAdmin) {
+		return tokenFactory.generateToken(member, type, isAdmin);
+	}
+
+	public String generateSignupToken(String kakaoId) {
+		return tokenFactory.generateSignupToken(kakaoId);
 	}
 }

--- a/src/main/java/com/ddobang/backend/global/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/ddobang/backend/global/security/oauth/OAuth2SuccessHandler.java
@@ -1,7 +1,6 @@
 package com.ddobang.backend.global.security.oauth;
 
 import java.io.IOException;
-import java.util.Optional;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -46,16 +45,15 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 		log.info("OAuth2 로그인 성공 - kakaoId: {}", kakaoId);
 
 		// 카카오 ID로 회원 정보 조회
-		Optional<Member> optionalMember = memberService.findByKakaoId(kakaoId);
+		Member searchMember = memberService.getByKakaoId(kakaoId);
 
-		// 회원 정보가 없으면 신규 회원으로 처리
-		if (optionalMember.isPresent()) {
-			// 기존 회원
-			authService.handleLoginSuccess(response, kakaoId);
+		if (searchMember != null) {
+			// 기존 회원: 토큰 생성 및 쿠키 저장
+			authService.handleLoginSuccess(response, searchMember);
 			log.info("기존 회원 로그인 처리 완료");
 			response.sendRedirect("/"); // 메인 페이지
 		} else {
-			// 신규 회원
+			// 신규 회원: 회원가입용 토큰 쿠키 전송
 			authService.handlePreSignup(response, kakaoId);
 			log.info("신규 회원 - 회원가입용 토큰 쿠키 전송 완료");
 			response.sendRedirect("/signup"); // 회원가입 페이지로 리다이렉트

--- a/src/main/java/com/ddobang/backend/global/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/ddobang/backend/global/security/oauth/OAuth2SuccessHandler.java
@@ -34,10 +34,13 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
 		// 인증된 사용자 정보 가져오기
 		OAuth2User oAuth2User = (OAuth2User)authentication.getPrincipal();
-		String kakaoId = (String)oAuth2User.getAttribute("id");
-		if (kakaoId == null) {
+		Object kakaoIdObj = oAuth2User.getAttribute("id");
+
+		if (kakaoIdObj == null) {
 			throw new OAuth2Exception(OAuth2ErrorCode.OAUTH2_MISSING_ID);
 		}
+
+		String kakaoId = kakaoIdObj.toString();
 
 		// 로그에 카카오 ID와 닉네임 출력
 		log.info("OAuth2 로그인 성공 - kakaoId: {}", kakaoId);

--- a/src/test/java/com/ddobang/backend/domain/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/com/ddobang/backend/domain/diary/controller/DiaryControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
@@ -29,6 +30,8 @@ import com.ddobang.backend.domain.diary.dto.response.DiaryListDto;
 import com.ddobang.backend.domain.diary.entity.Diary;
 import com.ddobang.backend.domain.diary.exception.DiaryException;
 import com.ddobang.backend.domain.diary.service.DiaryService;
+import com.ddobang.backend.domain.theme.entity.Theme;
+import com.ddobang.backend.domain.theme.repository.ThemeRepository;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -40,6 +43,8 @@ public class DiaryControllerTest {
 
 	@Autowired
 	private DiaryService diaryService;
+	@Autowired
+	private ThemeRepository themeRepository;
 
 	@Test
 	@DisplayName("탈출일지 등록")
@@ -1172,10 +1177,10 @@ public class DiaryControllerTest {
 			.perform(post("/api/v1/diaries/theme")
 				.content("""
 					{
-						"themeName": "테마 1",
-						"storeName": "방탈출 A",
-						"thumbnailUrl": "https://example.com/thumbnail.jpg",
-						"tags": ["공포", "판타지"]
+					    "themeName": "테마 1",
+					    "storeName": "방탈출 A",
+					    "thumbnailUrl": "https://example.com/thumbnail.jpg",
+					    "tags": ["공포", "판타지"]
 					}
 					""")
 				.contentType(
@@ -1184,13 +1189,15 @@ public class DiaryControllerTest {
 			)
 			.andDo(print());
 
+		Theme theme = themeRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt")).getFirst();
+
 		resultActions
 			.andExpect(handler().handlerType(DiaryController.class))
 			.andExpect(handler().methodName("saveThemeForDiary"))
 			.andExpect(status().isCreated())
 			.andExpect(jsonPath("$.message").value("테마 등록에 성공했습니다."))
-			.andExpect(jsonPath("$.data.themeId").value(23))
-			.andExpect(jsonPath("$.data.themeName").value("테마 1"));
+			.andExpect(jsonPath("$.data.themeId").value(theme.getId()))
+			.andExpect(jsonPath("$.data.themeName").value(theme.getName()));
 	}
 
 	@Test

--- a/src/test/java/com/ddobang/backend/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/ddobang/backend/domain/member/controller/MemberControllerTest.java
@@ -65,7 +65,7 @@ class MemberControllerTest {
 	void getMyBasicProfile_success() throws Exception {
 		// given
 		Member member = memberRepository.save(MemberTestFactory.full());
-		String token = jwtTokenProvider.generateToken(member.getNickname(), JwtTokenType.ACCESS, false);
+		String token = jwtTokenProvider.generateToken(member, JwtTokenType.ACCESS, false);
 
 		// when & then
 		mockMvc.perform(get("/api/v1/members/me")
@@ -84,7 +84,7 @@ class MemberControllerTest {
 		// given
 		Member target = memberRepository.save(MemberTestFactory.withNickname("오애순"));
 		Member requester = memberRepository.save(MemberTestFactory.withNickname("또방이"));
-		String token = jwtTokenProvider.generateToken(requester.getNickname(), JwtTokenType.ACCESS, false);
+		String token = jwtTokenProvider.generateToken(requester, JwtTokenType.ACCESS, false);
 
 		ProfileRequest request = new ProfileRequest(target.getId());
 
@@ -102,7 +102,7 @@ class MemberControllerTest {
 	void getOtherProfile_notFound() throws Exception {
 		// given
 		Member requester = memberRepository.save(MemberTestFactory.full());
-		String token = jwtTokenProvider.generateToken(requester.getNickname(), JwtTokenType.ACCESS, false);
+		String token = jwtTokenProvider.generateToken(requester, JwtTokenType.ACCESS, false);
 		ProfileRequest request = new ProfileRequest(9999L); // 없는 ID
 
 		// when & then

--- a/src/test/java/com/ddobang/backend/global/auth/AuthIntegrationTest.java
+++ b/src/test/java/com/ddobang/backend/global/auth/AuthIntegrationTest.java
@@ -22,6 +22,7 @@ import com.ddobang.backend.domain.member.repository.MemberRepository;
 import com.ddobang.backend.global.auth.dto.request.SignupRequest;
 import com.ddobang.backend.global.security.jwt.JwtTokenFactory;
 import com.ddobang.backend.global.security.jwt.JwtTokenType;
+import com.ddobang.backend.support.MemberTestFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.servlet.http.Cookie;
@@ -58,7 +59,8 @@ class AuthIntegrationTest {
 
 	// 테스트를 위한 JWT 토큰 쿠키 생성
 	private Cookie createSignupTokenCookie() {
-		String token = jwtTokenFactory.generateToken("12345678", JwtTokenType.SIGNUP, false);
+		Member member = MemberTestFactory.full();
+		String token = jwtTokenFactory.generateToken(member, JwtTokenType.SIGNUP, false);
 		Cookie cookie = new Cookie("signupToken", token);
 		cookie.setHttpOnly(true);
 		cookie.setPath("/");

--- a/src/test/java/com/ddobang/backend/global/auth/AuthIntegrationTest.java
+++ b/src/test/java/com/ddobang/backend/global/auth/AuthIntegrationTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.ddobang.backend.domain.diary.repository.DiaryRepository;
@@ -27,6 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.servlet.http.Cookie;
 
+@ActiveProfiles("test")
 @SpringBootTest
 @AutoConfigureMockMvc
 class AuthIntegrationTest {

--- a/src/test/java/com/ddobang/backend/global/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/ddobang/backend/global/auth/controller/AuthControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.ddobang.backend.global.auth.service.AuthService;
 
 @WebMvcTest(AuthController.class)
+@DisplayName("AuthController 테스트")
 class AuthControllerTest {
 
 	@Autowired
@@ -36,4 +37,3 @@ class AuthControllerTest {
 			.andExpect(redirectedUrlPattern("**/oauth2/authorization/kakao"));
 	}
 }
-

--- a/src/test/java/com/ddobang/backend/global/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/ddobang/backend/global/auth/service/AuthServiceTest.java
@@ -24,6 +24,7 @@ import com.ddobang.backend.global.exception.oauth2.OAuth2ErrorCode;
 import com.ddobang.backend.global.exception.oauth2.OAuth2Exception;
 import com.ddobang.backend.global.security.jwt.JwtTokenProvider;
 import com.ddobang.backend.global.security.jwt.JwtTokenType;
+import com.ddobang.backend.support.MemberTestFactory;
 
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -47,14 +48,14 @@ class AuthServiceTest {
 	@DisplayName("기존 회원 로그인 성공 - 액세스/리프레시 토큰 발급")
 	void loginSuccess() {
 		// given
-		String kakaoId = "12345678";
 		String accessToken = "access-token";
 		String refreshToken = "refresh-token";
-		given(jwtTokenProvider.generateToken(kakaoId, JwtTokenType.ACCESS, false)).willReturn(accessToken);
-		given(jwtTokenProvider.generateToken(kakaoId, JwtTokenType.REFRESH, false)).willReturn(refreshToken);
+		Member member = MemberTestFactory.full();
+		given(jwtTokenProvider.generateToken(member, JwtTokenType.ACCESS, false)).willReturn(accessToken);
+		given(jwtTokenProvider.generateToken(member, JwtTokenType.REFRESH, false)).willReturn(refreshToken);
 
 		// when / then
-		assertThatCode(() -> authService.handleLoginSuccess(response, kakaoId))
+		assertThatCode(() -> authService.handleLoginSuccess(response, member))
 			.doesNotThrowAnyException();
 	}
 
@@ -63,9 +64,6 @@ class AuthServiceTest {
 	void preSignupSuccess() {
 		// given
 		String kakaoId = "12345678";
-		String signupToken = "signup-token";
-		given(jwtTokenProvider.generateToken(kakaoId, JwtTokenType.SIGNUP, false)).willReturn(signupToken);
-
 		// when / then
 		assertThatCode(() -> authService.handlePreSignup(response, kakaoId))
 			.doesNotThrowAnyException();
@@ -97,8 +95,8 @@ class AuthServiceTest {
 		given(jwtTokenProvider.isValidToken(signupToken, JwtTokenType.SIGNUP)).willReturn(true);
 		given(jwtTokenProvider.extractKakaoId(signupToken)).willReturn(kakaoId);
 		given(memberService.registerMember(kakaoId, request)).willReturn(member);
-		given(jwtTokenProvider.generateToken(nickname, JwtTokenType.ACCESS, false)).willReturn("access-token");
-		given(jwtTokenProvider.generateToken(nickname, JwtTokenType.REFRESH, false)).willReturn("refresh-token");
+		given(jwtTokenProvider.generateToken(member, JwtTokenType.ACCESS, false)).willReturn("access-token");
+		given(jwtTokenProvider.generateToken(member, JwtTokenType.REFRESH, false)).willReturn("refresh-token");
 
 		// when / then
 		assertThatCode(() -> authService.signup(response, request, signupToken))

--- a/src/test/java/com/ddobang/backend/global/security/LoginMemberProviderTest.java
+++ b/src/test/java/com/ddobang/backend/global/security/LoginMemberProviderTest.java
@@ -3,6 +3,8 @@ package com.ddobang.backend.global.security;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -14,7 +16,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import com.ddobang.backend.domain.member.entity.Member;
-import com.ddobang.backend.domain.member.service.MemberService;
+import com.ddobang.backend.domain.member.repository.MemberRepository;
 import com.ddobang.backend.global.exception.jwt.JwtErrorCode;
 import com.ddobang.backend.global.exception.jwt.JwtException;
 
@@ -25,7 +27,7 @@ import com.ddobang.backend.global.exception.jwt.JwtException;
 class LoginMemberProviderTest {
 
 	@Mock
-	private MemberService memberService;
+	private MemberRepository memberRepository;
 
 	@InjectMocks
 	private LoginMemberProvider loginMemberProvider;
@@ -59,7 +61,7 @@ class LoginMemberProviderTest {
 
 		// MemberService가 반환할 Member 설정 (getCurrentMember()에서 호출됨)
 		Member mockMember = new Member(MEMBER_ID, NICKNAME);
-		when(memberService.getById(MEMBER_ID)).thenReturn(mockMember);
+		when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(mockMember));
 
 		// when: 실제 메서드 호출
 		Member currentMember = loginMemberProvider.getCurrentMember();

--- a/src/test/java/com/ddobang/backend/global/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/ddobang/backend/global/security/jwt/JwtTokenProviderTest.java
@@ -8,6 +8,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import com.ddobang.backend.domain.member.entity.Member;
+import com.ddobang.backend.support.MemberTestFactory;
+
 import jakarta.servlet.http.HttpServletRequest;
 
 class JwtTokenProviderTest {
@@ -93,10 +96,11 @@ class JwtTokenProviderTest {
 	@Test
 	@DisplayName("토큰 생성 위임 확인")
 	void generateToken_shouldDelegate() {
-		given(tokenFactory.generateToken("ddobang", JwtTokenType.ACCESS, false))
+		Member member = MemberTestFactory.full();
+		given(tokenFactory.generateToken(member, JwtTokenType.ACCESS, false))
 			.willReturn("access.jwt.token");
 
-		String token = jwtTokenProvider.generateToken("ddobang", JwtTokenType.ACCESS, false);
+		String token = jwtTokenProvider.generateToken(member, JwtTokenType.ACCESS, false);
 
 		assertThat(token).isEqualTo("access.jwt.token");
 	}


### PR DESCRIPTION
<!-- 제목 : [FEAT] 구현한 기능 -->
<!-- #[이슈 번호] -->

## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [ ] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
- 기존 Kakao ID를 Long으로 처리하던 문제를 String으로 통일하여 오류 수정
- JWT 토큰의 subject 필드를 memberId로 변경
- JWT 페이로드 구조 개선: nickname, isAdmin, type 등 포함
- 기존 Optional<Member> 처리 방식 제거 → getByKakaoId(String) 방식으로 통일
- JwtTokenProvider, JwtTokenFactory, JwtAuthenticationFilter 등 구조 정리
- 신규 회원일 경우 /signup으로 리다이렉트 처리 수정
- 로직 변경에 따른 테스트 수정