### PR TITLE
feat: OAuth2 로그인 성공 시 프론트엔드 도메인으로 리다이렉트 처리

### DIFF
--- a/src/main/java/com/ddobang/backend/BackendApplication.java
+++ b/src/main/java/com/ddobang/backend/BackendApplication.java
@@ -2,12 +2,13 @@ package com.ddobang.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@ConfigurationPropertiesScan
 public class BackendApplication {
-
 	public static void main(String[] args) {
 		SpringApplication.run(BackendApplication.class, args);
 	}

--- a/src/main/java/com/ddobang/backend/global/security/oauth/OAuth2RedirectProperties.java
+++ b/src/main/java/com/ddobang/backend/global/security/oauth/OAuth2RedirectProperties.java
@@ -1,0 +1,23 @@
+package com.ddobang.backend.global.security.oauth;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Component
+@Validated
+@ConfigurationProperties(prefix = "custom.oauth2.redirect.frontend")
+public class OAuth2RedirectProperties {
+
+	@NotBlank
+	private String main; // 메인 페이지 URL
+
+	@NotBlank
+	private String signup; // 회원가입 페이지 URL
+}

--- a/src/main/java/com/ddobang/backend/global/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/ddobang/backend/global/security/oauth/OAuth2SuccessHandler.java
@@ -25,6 +25,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
 	private final MemberService memberService;
 	private final AuthService authService;
+	private final OAuth2RedirectProperties redirectProperties;
 
 	// OAuth2 로그인 성공 시 호출되는 메서드
 	@Override
@@ -35,10 +36,12 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 		OAuth2User oAuth2User = (OAuth2User)authentication.getPrincipal();
 		Object kakaoIdObj = oAuth2User.getAttribute("id");
 
+		// 카카오 ID가 null인 경우 예외 처리
 		if (kakaoIdObj == null) {
 			throw new OAuth2Exception(OAuth2ErrorCode.OAUTH2_MISSING_ID);
 		}
 
+		// 카카오 ID를 문자열로 변환
 		String kakaoId = kakaoIdObj.toString();
 
 		// 로그에 카카오 ID와 닉네임 출력
@@ -46,17 +49,22 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
 		// 카카오 ID로 회원 정보 조회
 		Member searchMember = memberService.getByKakaoId(kakaoId);
+		if (searchMember == null) {
+			log.info("신규 회원 - 카카오 ID로 회원 정보 조회 결과 없음");
+		} else {
+			log.info("기존 회원 - 카카오 ID로 회원 정보 조회 결과: {}", searchMember);
+		}
 
 		if (searchMember != null) {
 			// 기존 회원: 토큰 생성 및 쿠키 저장
 			authService.handleLoginSuccess(response, searchMember);
 			log.info("기존 회원 로그인 처리 완료");
-			response.sendRedirect("/"); // 메인 페이지
+			response.sendRedirect(redirectProperties.getMain()); // 메인 페이지로 리다이렉트
 		} else {
 			// 신규 회원: 회원가입용 토큰 쿠키 전송
 			authService.handlePreSignup(response, kakaoId);
 			log.info("신규 회원 - 회원가입용 토큰 쿠키 전송 완료");
-			response.sendRedirect("/signup"); // 회원가입 페이지로 리다이렉트
+			response.sendRedirect(redirectProperties.getSignup()); // 회원가입 페이지로 리다이렉트
 		}
 	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,7 +27,6 @@ spring:
         highlight_sql: true
         use_sql_comments: true
 
-  # security
   security:
     oauth2:
       client:
@@ -78,3 +77,10 @@ custom:
     timeout: 600000  # SSE 타임아웃 설정 (밀리초, 10분)
   fileUpload:
     dirPath: c:/temp/ddobang_dev
+
+  # OAuth2 redirect URIs
+  oauth2:
+    redirect:
+      frontend:
+        main: https://www.ddobang.site/
+        signup: https://www.ddobang.site/signup


### PR DESCRIPTION
- 기존 회원은 로그인 후 main 페이지로, 신규 회원은 /signup 페이지로 리다이렉트 되도록 분기 처리
- 리다이렉트 URL을 application.yml의 custom.oauth2.redirect.frontend에서 관리
- OAuth2RedirectProperties 클래스에서 main, signup URL 주입받도록 구성

<!-- 제목 : [FEAT] 구현한 기능 -->
<!-- #[이슈 번호] -->

## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
- 기존 회원은 로그인 후 main 페이지로, 신규 회원은 /signup 페이지로 리다이렉트 되도록 분기 처리
- 리다이렉트 URL을 application.yml의 custom.oauth2.redirect.frontend에서 관리
- OAuth2RedirectProperties 클래스에서 main, signup URL 주입받도록 구성